### PR TITLE
Draft Messaging

### DIFF
--- a/TPOT Electron/src/apps/Letters.jsx
+++ b/TPOT Electron/src/apps/Letters.jsx
@@ -25,8 +25,8 @@ class Letters extends React.Component {
         const childProps = { authUser: this.props.authUser }
         return (
             <div className="Letters">
-                <Header color="primary" onUpdate={this.onUpdateHeader} editMode={this.state.editMode} {...childProps} />
-                <Editor editMode={this.state.editMode} />
+                <Header color="primary" onUpdate={this.onUpdateHeader} {...childProps} />
+                <Editor />
                 <PublishScreenContainer/>
             </div>
         )

--- a/TPOT Electron/src/container/PublishScreenContainer.jsx
+++ b/TPOT Electron/src/container/PublishScreenContainer.jsx
@@ -9,17 +9,18 @@ class PublishScreenContainer extends Component {
     }
 
     render() {
-        const { lettersStore: store, ...rest } = this.props
+        let { lettersStore: store, ...rest } = this.props
+        let editorCode = this.props.editorStore.editorCode
         
         return (
             <Fragment>
-                <PublishScreen comments={store.publishData} store={store} {...rest} />
+                <PublishScreen comments={store.publishData} store={store} editorCode={editorCode} {...rest} />
             </Fragment>
         )
     }
 }
 
 export default compose(
-    inject('lettersStore'),
+    inject('lettersStore', 'editorStore'),
     observer
 )(PublishScreenContainer)

--- a/TPOT Electron/src/editor/Code.jsx
+++ b/TPOT Electron/src/editor/Code.jsx
@@ -1,98 +1,39 @@
 import PropTypes from "prop-types";
-import React, { Fragment } from "react";
+import React, { Component } from "react";
+import { inject, observer } from "mobx-react";
+import { compose } from "recompose";
 import SyntaxHighlighter from 'react-syntax-highlighter';
 import * as hljs from 'react-syntax-highlighter/dist/esm/styles/hljs';
 
-import { inject, observer, Provider } from "mobx-react";
-import { observable, action, computed, decorate, autorun } from 'mobx'
-import { compose } from "recompose";
+class Code extends Component {
 
-
-const MUIstyles = theme => ({
-	root: {
-		// display: "flex",
-		// flexWrap: "wrap",
-		// flexGrow: 1,
-		// background: "white",
-		// height: "calc(100vh - 104px)",
-		// boxShadow: "0px",
-		// overflow: "hidden"
-		// border: '4px solid lime',
-	},
-});
-
-class Code extends React.Component {
-	// state = {
-	// 	originalState: "I am Original",
-	// 	editorState: createEditorStateWithText(
-	// 		"This is some starter text. Start typing!"
-	// 	),
-	// 	codeState: "I am Code",
-	// 	baseStyleMap: baseStyleMap
-	// };
-
-	componentDidMount() {
-		const { lettersStore: store } = this.props
-		// store.setEditorState('edited', EditorState.createEmpty())
-
-		// window.addEventListener("message", msg => {
-		// 	if (msg.data.event === "draftjs-editor-reload") {
-		// 		this.reloadEditor(msg.data.html);
-		// 	}
-		// 	if (msg.data.event === "draftjs-editor-get-code") {
-		// 		this.getCode();
-		// 	}
-		// });
-	}
-
-
-	// After the class is constructed and its data is mounted to the React DOM, render() is fired, which takes displays the elements with data from the instance's current state.
 	render() {
-		const { lettersStore: store, classes, editMode } = this.props;
-		console.log(this.props)
-		// console.log(store.editedState)
-		// this.setState({editorState: store.editedState})
-		//         const { lettersStore: store } = this.props
-		// store.setEditorState('edited', editorState)
-		//     	onChange = editorState => {
-		//     const { lettersStore: store } = this.props
-		//     store.setEditorState('edited', editorState)
-		// 	// this.setState({
-		// 	// 	editorState
-		// 	// });
-		// };
+		const { editorStore: store } = this.props;
+
 		return (
 			<SyntaxHighlighter
 				showLineNumbers
 				wrapLines
-				lineProps={{ style: { border: '0px solid yellow' } }}
-				children={this.props.editorStore.codeState}
 				language='html'
+				children={store.editorCode}
 				style={hljs.solarizedLight}
-				customStyle={{
-					border: '0PXsolid blue',
-					borderRadius: 16,
-					background: 'transparent',
-					overflow: 'hidden',
-					textOverflow: 'ellipsis',
-					// fontFamily: 'Monda',
-					// fontWeight: 'bold',
-					// fontSize: 16,
-				}}
+				lineProps={{ style: { border: '0px solid yellow' } }}
 				codeTagProps={{ style: { border: '0px solid red' } }}
+				customStyle={{
+					overflow: 'hidden',
+					background: 'transparent',
+					textOverflow: 'ellipsis',
+				}}
 			/>
 		);
 	}
 }
 
 Code.propTypes = {
-	// classes: PropTypes.object.isRequired
+	editorStore: PropTypes.object.isRequired
 };
 
 export default compose(
 	inject('editorStore'),
-	// withStyles(MUIstyles),
 	observer
 )(Code);
-
-// export default withStyles(MUIstyles)(Wysiwyg)

--- a/TPOT Electron/src/editor/Draft.jsx
+++ b/TPOT Electron/src/editor/Draft.jsx
@@ -7,21 +7,6 @@ import Editor from "draft-js-plugins-editor";
 
 class Draft extends Component {
 
-	componentDidMount() {
-		const { lettersStore: store } = this.props
-
-		window.addEventListener("message", msg => {
-			if (msg.data.event === "draftjs-editor-reload") {
-				this.props.editorStore.loadEditorFromDocx(msg.data.html)
-				// this.reloadEditor(msg.data.html);
-			}
-			if (msg.data.event === "draftjs-editor-get-code") {
-				// this.getCode();
-				// console.log(this.props.editorStore.editorCode)
-			}
-		});
-	}
-
 	onChange = editorState =>
 		this.props.editorStore.onChange(editorState)
 
@@ -30,11 +15,8 @@ class Draft extends Component {
 		if (this.editor) { this.editor.focus(); }
 	};
 
-	// After the class is constructed and its data is mounted to the React DOM, render() is fired, which takes displays the elements with data from the instance's current state.
 	render() {
-		const { classes, editMode } = this.props;
 		const store = { ...this.props.lettersStore, ...this.props.editorStore }
-		console.log(store)
 
 		return (
 			<Fragment>
@@ -62,11 +44,11 @@ class Draft extends Component {
 }
 
 Draft.propTypes = {
-	editorStore: PropTypes.object.isRequired
+	editorStore: PropTypes.object.isRequired,
+	lettersStore: PropTypes.object.isRequired
 };
 
 export default compose(
 	inject('lettersStore', 'editorStore'),
-	// withStyles(MUIstyles),
 	observer
 )(Draft);

--- a/TPOT Electron/src/editor/Editor.jsx
+++ b/TPOT Electron/src/editor/Editor.jsx
@@ -1,7 +1,7 @@
-import { withStyles } from "@material-ui/core/styles";
-import { inject, observer, Provider } from "mobx-react";
 import PropTypes from "prop-types";
 import React from "react";
+import { withStyles } from "@material-ui/core/styles";
+import { inject, observer } from "mobx-react";
 import { compose } from "recompose";
 import Code from "./Code";
 import Draft from "./Draft";
@@ -16,7 +16,6 @@ const MUIstyles = theme => ({
 		height: "calc(100vh - 104px)",
 		boxShadow: "0px",
 		overflow: "hidden"
-		// border: '4px solid lime',
 	},
 	editorFrame: {
 		padding: 80,
@@ -30,30 +29,18 @@ const MUIstyles = theme => ({
 		maxWidth: 1000,
 		overflowX: "hidden",
 		overflowY: "scroll"
-		// backgroundColor: '#f0f0f0',
-		// border: '4px solid blue !important',
 	},
 });
 
 class Editor extends React.Component {
 
-	componentDidMount() {
-		const { lettersStore: store } = this.props
-	}
-
-
-	// After the class is constructed and its data is mounted to the React DOM, render() is fired, which takes displays the elements with data from the instance's current state.
 	render() {
-		const { lettersStore: store, classes, editMode } = this.props;
-		// const { editMode } = store
+		const { editorStore: store, classes } = this.props;
+		const { editMode } = store
 
 		return (
 			<div id="Editor" className={classes.root}>
-				{/* <noscript>{store.editedState.toString()}</noscript> */}
-				<div id="Frame" className={classes.editorFrame}
-				// onClick={this.focus}
-				>
-					{/* <button onClick={this.saveSession}>Feed Me</button> */}
+				<div id="Frame" className={classes.editorFrame}>
 					{editMode === "edited" && <Draft />}
 					{editMode === "original" && <Original />}
 					{editMode === "code" && <Code />}
@@ -68,9 +55,7 @@ Editor.propTypes = {
 };
 
 export default compose(
-	inject('lettersStore'),
+	inject('editorStore'),
 	withStyles(MUIstyles),
 	observer
 )(Editor);
-
-// export default withStyles(MUIstyles)(Wysiwyg)

--- a/TPOT Electron/src/editor/Original.jsx
+++ b/TPOT Electron/src/editor/Original.jsx
@@ -1,23 +1,12 @@
 import PropTypes from "prop-types";
-import React, { Fragment } from "react";
+import React, { Fragment, Component } from "react";
+import { inject, observer } from "mobx-react";
+import { compose } from "recompose";
 import ReactHtmlParser from "react-html-parser";
 
-import { inject, observer, Provider } from "mobx-react";
-import { observable, action, computed, decorate, autorun } from 'mobx'
-import { compose } from "recompose";
+class Original extends Component {
 
-class Original extends React.Component {
-
-	componentDidMount() {
-		const { lettersStore: store } = this.props
-		// store.setEditorState('edited', EditorState.createEmpty())
-	}
-
-
-	// After the class is constructed and its data is mounted to the React DOM, render() is fired, which takes displays the elements with data from the instance's current state.
 	render() {
-		const { lettersStore: store, classes, editMode } = this.props;
-
 		return (
 			<Fragment>
 				{ReactHtmlParser(this.props.editorStore.originalState)}
@@ -27,13 +16,10 @@ class Original extends React.Component {
 }
 
 Original.propTypes = {
-	// classes: PropTypes.object.isRequired
+	editorStore: PropTypes.object.isRequired
 };
 
 export default compose(
 	inject('editorStore'),
-	// withStyles(MUIstyles),
 	observer
 )(Original);
-
-// export default withStyles(MUIstyles)(Wysiwyg)

--- a/TPOT Electron/src/presentation/EditMode.jsx
+++ b/TPOT Electron/src/presentation/EditMode.jsx
@@ -1,6 +1,11 @@
-import React from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { withStyles } from '@material-ui/core/styles';
+
+import { inject, observer, Provider } from "mobx-react";
+import { observable, action, computed, decorate, autorun, toJS } from 'mobx'
+import { compose } from "recompose";
+
 
 import CodeIcon from '@material-ui/icons/Code'
 import FileIcon from '@material-ui/icons/InsertDriveFileOutlined'
@@ -60,7 +65,7 @@ const styles = theme => ({
 
 });
 
-class EditMode extends React.Component {
+class EditMode extends Component {
     constructor(props) {
         super(props)
 
@@ -89,6 +94,9 @@ class EditMode extends React.Component {
     }
 
     handleChange = (e, tab) => {
+        // console.log(e, tab)
+        // console.log(this.props.lettersStore.setEditMode)
+        this.props.lettersStore.setEditMode(tab)
         this.setState({ currentTab: tab }); // update self
         let editMode
         switch (tab) {
@@ -109,25 +117,23 @@ class EditMode extends React.Component {
     };
 
     render() {
-        const { classes } = this.props;
+        const { editorStore: store, classes } = this.props;
 
         return (
-
-                <Tabs
-                    classes={{ root: classes.tabsRoot, indicator: classes.indicator }}
-                    value={this.state.currentTab}
-                    onChange={this.handleChange}
-                    onClick={this.getCodeFromEditor}
-                    fullWidth
-                    indicatorColor="primary"
-                    textColor="inherit"
-                >
-                    {this.tabs.map((tab) => {
-                        return (
-                            <Tab classes={{ root: classes.tabRoot, selected: classes.selected }} icon={tab.icon} label={tab.name} key={Math.random(tab.name)} />
-                        );
-                    })}
-                </Tabs>
+            <Tabs
+                classes={{ root: classes.tabsRoot, indicator: classes.indicator }}
+                value={store.editModeKey}
+                onChange={(e, tab)=> store.setEditMode(e, tab)}
+                fullWidth
+                indicatorColor="primary"
+                textColor="inherit"
+            >
+                {this.tabs.map((tab) => {
+                    return (
+                        <Tab classes={{ root: classes.tabRoot, selected: classes.selected }} icon={tab.icon} label={tab.name} key={Math.random(tab.name)} />
+                    );
+                })}
+            </Tabs>
         );
     }
 }
@@ -136,4 +142,10 @@ EditMode.propTypes = {
     classes: PropTypes.object,
 };
 
-export default withStyles(styles)(EditMode);
+// export default withStyles(styles)(EditMode);
+
+export default compose(
+	inject('editorStore'),
+	withStyles(styles),
+	observer
+)(EditMode);

--- a/TPOT Electron/src/presentation/PublishScreen.jsx
+++ b/TPOT Electron/src/presentation/PublishScreen.jsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react'
-import { observer } from 'mobx-react'
+import { observer, inject } from 'mobx-react'
 import { compose } from 'recompose'
 import classNames from 'classnames';
 import { withStyles } from '@material-ui/core/styles'
@@ -51,15 +51,15 @@ const styles = theme => ({
 })
 
 // Main Class
-const PublishScreen = observer(({ classes, store }) => (
+const PublishScreen = observer(({ classes, store, editorCode }) => (
     <main id="PublishScreen">
         <Dialog open={store.publishModal} onBackdropClick={e => { store.togglePublishModal() }} disablePortal={true} scroll={'body'} classes={{ root: classes.root, container: classes.backdrop, paper: classes.paper }} >
-            <PublishForm classes={classes} store={store} />
+            <PublishForm classes={classes} store={store} editorCode={editorCode} />
         </Dialog>
     </main>
 ))
 
-const PublishForm = ({ classes, store }) => (
+const PublishForm = ({ classes, store, editorCode }) => (
     <Fragment>
         <Typography variant="h4" align="center">Publish</Typography>
         <Grid container spacing={16} alignItems="center">
@@ -68,7 +68,7 @@ const PublishForm = ({ classes, store }) => (
             <InputField half="true" label="Title" onChange={e => { store.setPublishData('title', e.target.value) }} />
             <InputField half="true" label="Slug" onChange={e => { store.setPublishData('slug', e.target.value) }} />
             <InputField label="Excerpt (optional)" onChange={e => { store.setPublishData('excerpt', e.target.value) }} multiline rows={3} helperText="Enter a brief, meaningful description for search results." />
-            <FormButtons classes={classes} store={store} />
+            <FormButtons classes={classes} store={store} editorCode={editorCode} />
         </Grid>
     </Fragment>
 )
@@ -89,13 +89,10 @@ const InputField = (props) => (
         : <Grid item xs={12}><TextField fullWidth variant="outlined" {...props} /></Grid>
 )
 
-const FormButtons = ({ classes, store }) => (
+const FormButtons = ({ classes, store, editorCode }) => (
     <div className={classes.buttons}>
         <Button variant="contained" onClick={this.handleNext} className={classes.button} >Preview</Button>
-        <Button variant="contained" color="primary" onClick={() => {
-            window.postMessage({ event: "draftjs-editor-get-code" }, "*")
-            setTimeout(() => { store.publishToWordpress() }, 500);
-        }} className={classes.button} >Submit</Button>
+        <Button variant="contained" color="primary" onClick={() => store.publishToWordpress(editorCode)} className={classes.button} >Submit</Button>
     </div>
 )
 
@@ -105,6 +102,7 @@ const PublishIcon = ({ classes }) => (
 
 // Main Export
 export default compose(
+    // inject('editorStore'),
     withStyles(styles),
-    // observer
+    observer
 )(PublishScreen)

--- a/TPOT Electron/src/stores/editor.js
+++ b/TPOT Electron/src/stores/editor.js
@@ -1,23 +1,17 @@
-import { observable, action, decorate, computed, toJS } from 'mobx'
-
-// Draft JS
-import {
-    baseBlockStyleFn,
-    baseStyleMap,
-    blockRenderer,
-    blockRenderMap,
-    draftContentFromHtml,
-    draftContentToHtml,
-    stateFromElementConfig
-} from "../editor/utils/transforms";
-import { convertToRaw, getDefaultKeyBinding, KeyBindingUtil, EditorState } from "draft-js";
-import Editor, { createEditorStateWithText } from "draft-js-plugins-editor";
-
+import { EditorState, getDefaultKeyBinding, KeyBindingUtil } from "draft-js";
+import { createEditorStateWithText } from "draft-js-plugins-editor";
+import { action, computed, decorate, observable } from 'mobx';
+import { baseBlockStyleFn, baseStyleMap, blockRenderer, blockRenderMap, draftContentFromHtml, draftContentToHtml, stateFromElementConfig } from "../editor/utils/transforms";
 
 class EditorStore {
 
     constructor(rootStore) {
         this.rootStore = rootStore
+
+        window.addEventListener("message", msg => {
+            if (msg.data.event === "draftjs-editor-reload") this.loadEditorFromDocx(msg.data.html)
+        });
+
     }
 
     originalState = 'Original'
@@ -28,6 +22,12 @@ class EditorStore {
     blockRenderer = blockRenderer
     blockRenderMap = blockRenderMap
     editorNode = null
+    editMode = 'edited'
+    modes = [
+        'original',
+        'edited',
+        'code',
+    ]
 
     onChange = editorState =>
         this.editorState = editorState
@@ -36,84 +36,88 @@ class EditorStore {
         this.editorNode = node
 
     focus = () => {
-        if (this.editor) { this.editorNode.focus(); }
+        if (this.editor) this.editorNode.focus()
     }
 
     loadEditorFromDocx = html => {
-        let baseStyleMapClear = JSON.parse(JSON.stringify(Object.assign(toJS(baseStyleMap))))
-        const { newContentState, newBaseStyleMap } = draftContentFromHtml( html, stateFromElementConfig, baseStyleMap);
+        // let baseStyleMapClear = JSON.parse(JSON.stringify(Object.assign(toJS(baseStyleMap))))
+        const { newContentState, newBaseStyleMap } = draftContentFromHtml(html, stateFromElementConfig, baseStyleMap);
         this.originalState = html
         this.baseStyleMap = newBaseStyleMap
         this.editorState = EditorState.createWithContent(newContentState);
         this.codeState = draftContentToHtml(this.editorState, newContentState);
     }
 
-    get editorCode() {
-        return draftContentToHtml(
-			this.editorState,
-			this.editorState.getCurrentContent()
-        );
-    }
+    setEditMode = (e, tab) =>
+        this.editMode = this.modes[tab]
 
-    setStyleMap = customStyleMap =>{
-        console.log('setstylemap', customStyleMap)
+    setStyleMap = customStyleMap =>
         this.baseStyleMap = customStyleMap
-    }
 
     handleKeyCommand = (command, store) => {
-		if (command === 'save') {
-			store.saveSession()
-			return 'handled';
-		}
-		if (command === 'open') {
-			store.saveSession()
-			console.log('load file')
-			return 'handled';
-		}
-		if (command === 'publish') {
-			store.togglePublishModal()
-			return 'handled';
-		}
-		return 'not-handled';
+        if (command === 'save') {
+            store.saveSession()
+            return 'handled';
+        }
+        if (command === 'open') {
+            store.saveSession()
+            console.log('load file')
+            return 'handled';
+        }
+        if (command === 'publish') {
+            store.togglePublishModal()
+            return 'handled';
+        }
+        return 'not-handled';
     }
-    
+
     myKeyBindingFn = (e) => {
-		const { hasCommandModifier } = KeyBindingUtil;
-		if (e.keyCode === 83 /* `S` key */ && hasCommandModifier(e)) {
-			return 'save'
-		}
-		if (e.keyCode === 79 /* `O key */ && hasCommandModifier(e)) {
-			return 'open'
-		}
-		if (e.keyCode === 80 /* `S` key */ && hasCommandModifier(e)) {
-			return 'publish'
-		}
-		return getDefaultKeyBinding(e);
-	}
+        const { hasCommandModifier } = KeyBindingUtil;
+        if (e.keyCode === 83 /* `S` key */ && hasCommandModifier(e)) {
+            return 'save'
+        }
+        if (e.keyCode === 79 /* `O key */ && hasCommandModifier(e)) {
+            return 'open'
+        }
+        if (e.keyCode === 80 /* `P` key */ && hasCommandModifier(e)) {
+            return 'publish'
+        }
+        return getDefaultKeyBinding(e);
+    }
+
+    get editModeKey() {
+        return this.modes.indexOf(this.editMode)
+    }
+
+    get editorCode() {
+        return draftContentToHtml(
+            this.editorState,
+            this.editorState.getCurrentContent()
+        );
+    }
 
 }
 
 export default decorate(
     EditorStore, {
-
         originalState: observable,
-        codeState: observable,
-
-        editorCode: computed,
-
         editorState: observable,
-        editorNode: observable,
-
+        codeState: observable,
         baseStyleMap: observable,
         baseBlockStyleFn: observable,
         blockRenderer: observable,
-        blockRenderMap: observable,   
-
-        handleKeyCommand: action,
-        setStyleMap: action,
-        setRef: action,
+        blockRenderMap: observable,
+        editorNode: observable,
+        editMode: observable,
+        modes: observable,
         onChange: action,
+        setRef: action,
+        focus: action,
         loadEditorFromDocx: action,
-        setSessionName: action,
-
+        setEditMode: action,
+        setStyleMap: action,
+        handleKeyCommand: action,
+        myKeyBindingFn: action,
+        editModeKey: computed,
+        editorCode: computed,
     })

--- a/TPOT Electron/src/stores/letters.js
+++ b/TPOT Electron/src/stores/letters.js
@@ -1,8 +1,8 @@
-import { observable, action, computed, decorate, autorun } from 'mobx'
+import { observable, action, decorate } from 'mobx'
 import { db, auth } from '../firebase' 
 import { wp } from '../wordpress'
 import { draft } from '../editor'
-import { convertToRaw, EditorState } from "draft-js";
+import { EditorState } from "draft-js";
 
 class LettersStore {
     constructor(rootStore) {
@@ -79,7 +79,6 @@ class LettersStore {
     }
 
     publishToWordpress = async (html) => {
-        // wp.getCatg()
         console.log(html)
         console.log('published to wordpress')
         const wpCreds = await db.wordpressCredentials
@@ -88,7 +87,7 @@ class LettersStore {
             ? wpCreds
             : null
         wp.createPage(this.wordpressCredentials, {
-            content: this.editorContent,
+            content: html,
             slug: this.publishData.slug,
             title: this.publishData.title,
             excerpt: this.publishData.excerpt,


### PR DESCRIPTION
Cleaned up all unused code from Editor directory. Editor is able to listen to window commands and do certain functions. Publish container updated to get computed code state directly instead of through messaging and timeouts. Transforms moved to MobX store, so now they can operate on the most recent versions of baseStyleMap, contentState, and blockRenderer, etc. This will be finalized and cleaned up later (big transforms.jsx file)